### PR TITLE
Fix:  Enable hawkc to be compiled by g++ compiler

### DIFF
--- a/hawk/hawk.c
+++ b/hawk/hawk.c
@@ -22,7 +22,7 @@ static char *PORT80 = "80";
 
 static char *mystrdup(const char *in, const char *fieldname) {
 	char *p;
-	if( (p = malloc(strlen(in)+1)) == NULL) {
+	if( (p = (char *)malloc(strlen(in)+1)) == NULL) {
 		fprintf(stderr,"Unable to allocate for %s\n" , fieldname);
 		exit(1);
 	}
@@ -33,7 +33,11 @@ static char *mystrdup(const char *in, const char *fieldname) {
 int main(int argc, char **argv) {
 
 	HawkcError e;
-	struct HawkcContext ctx;
+#ifdef __cplusplus
+	_HawkcContext ctx;
+#else
+        struct HawkcContext ctx;
+#endif
 	char *id = NULL;
 	char *password = NULL;
 	char *method = NULL;

--- a/hawkc/authorization.c
+++ b/hawkc/authorization.c
@@ -222,7 +222,7 @@ HawkcError hawkc_calculate_authorization_header_length(HawkcContext ctx, size_t 
 				return hawkc_set_error(ctx,
 						HAWKC_REQUIRED_BUFFER_TOO_LARGE, "Required base string buffer of %d bytes exceeds MAX_DYN_BASE_BUFFER_SIZE" , required_size);
 			}
-			if( (dyn_base_buf = hawkc_calloc(ctx,1,required_size)) == NULL) {
+			if( (dyn_base_buf = (unsigned char *)hawkc_calloc(ctx,1,required_size)) == NULL) {
 				return hawkc_set_error(ctx,
 						HAWKC_NO_MEM, "Unable to allocate %d bytes for dynamic base buffer" , required_size);
 			}
@@ -377,7 +377,7 @@ HawkcError hawkc_validate_hmac(HawkcContext ctx,int *is_valid) {
 			return hawkc_set_error(ctx,
 					HAWKC_REQUIRED_BUFFER_TOO_LARGE, "Required base string buffer of %d bytes exceeds MAX_DYN_BASE_BUFFER_SIZE" , required_size);
 		}
-		if( (dyn_base_buf = hawkc_calloc(ctx,1,required_size)) == NULL) {
+		if( (dyn_base_buf = (unsigned char *)hawkc_calloc(ctx,1,required_size)) == NULL) {
 			return hawkc_set_error(ctx,
 					HAWKC_NO_MEM, "Unable to allocate %d bytes for dynamic base buffer" , required_size);
 		}

--- a/hawkc/common.c
+++ b/hawkc/common.c
@@ -16,8 +16,13 @@
  * Also, you must add to the selection if-cascades in crypto_openssl.c for them
  * to be recognized.
  */
+#if __cplusplus
+struct _HawkcAlgorithm _HAWKC_SHA_256 = { "sha256" };
+struct _HawkcAlgorithm _HAWKC_SHA_1 = { "sha1" };
+#else
 struct HawkcAlgorithm _HAWKC_SHA_256 = { "sha256" };
 struct HawkcAlgorithm _HAWKC_SHA_1 = { "sha1" };
+#endif
 
 HawkcAlgorithm HAWKC_SHA_256 = &_HAWKC_SHA_256;
 HawkcAlgorithm HAWKC_SHA_1 = &_HAWKC_SHA_1;
@@ -65,7 +70,11 @@ HawkcError hawkc_get_error_code(HawkcContext ctx) {
 
 
 void hawkc_context_init(HawkcContext ctx) {
-	memset(ctx,0,sizeof(struct HawkcContext));
+#ifdef __cplusplus
+	memset(ctx,0,sizeof(struct _HawkcContext));
+#else
+        memset(ctx,0,sizeof(struct HawkcContext));
+#endif
 	ctx->error = HAWKC_OK;
 	ctx->malloc = NULL;
 	ctx->calloc = NULL;

--- a/hawkc/common.h
+++ b/hawkc/common.h
@@ -18,7 +18,12 @@ typedef HawkcError (*HawkcParamHandler) (HawkcContext ctx, HawkcString key, Hawk
 
 /** Structure for the Algorithm typedef in hawkc.h
  */
+
+#if __cplusplus
+struct _HawkcAlgorithm {
+#else
 struct HawkcAlgorithm {
+#endif
 	const char* name;
 };
 

--- a/hawkc/hawkc.h
+++ b/hawkc/hawkc.h
@@ -97,12 +97,20 @@ typedef enum {
  * library with automatic variable and no
  * need to allocate memory for context.
  */
+#ifdef __cplusplus
+typedef struct _HawkcContext *HawkcContext;
+#else
 typedef struct HawkcContext *HawkcContext;
+#endif
 
 /*
  * Type for HMAC algorithms supplied by hawkc library.
  */
+#ifdef __cplusplus
+typedef struct _HawkcAlgorithm *HawkcAlgorithm;
+#else
 typedef struct HawkcAlgorithm *HawkcAlgorithm;
+#endif
 
 /*
  * Memory allocation function pointers. Hawkc allows setting custom
@@ -118,7 +126,11 @@ typedef void (*HawkcFreeFunc)(HawkcContext ctx, void *ptr);
  * header data. This struct is used for storing parsed data as
  * well as for constructing header data before creating a string representation.
  */
+#ifdef __cplusplus
+typedef struct _AuthorizationHeader {
+#else
 typedef struct AuthorizationHeader {
+#endif
 	HawkcString id;
 	HawkcString mac;
 	HawkcString hash;
@@ -135,7 +147,11 @@ typedef struct AuthorizationHeader {
  * header data. This struct is used for storing parsed data as
  * well as for constructing header data before creating a string representation.
  */
+#ifdef __cplusplus
+typedef struct _WwwAuthenticateHeader {
+#else
 typedef struct WwwAuthenticateHeader {
+#endif
 	time_t ts;
 	HawkcString tsm;
 } *WwwAuthenticateHeader;
@@ -157,7 +173,11 @@ typedef struct WwwAuthenticateHeader {
  *
  *
  */
+#ifdef __cplusplus
+struct _HawkcContext {
+#else
 struct HawkcContext {
+#endif
 	HawkcMallocFunc malloc;
 	HawkcCallocFunc calloc;
 	HawkcFreeFunc free;
@@ -173,9 +193,15 @@ struct HawkcContext {
 	HawkcString host;
 	HawkcString port;
 
+#ifdef __cplusplus
+        struct _AuthorizationHeader header_in;
+        struct _AuthorizationHeader header_out;
+	struct _WwwAuthenticateHeader www_authenticate_header;
+#else
 	struct AuthorizationHeader header_in;
 	struct AuthorizationHeader header_out;
 	struct WwwAuthenticateHeader www_authenticate_header;
+#endif
 
 	unsigned char hmac_buffer[MAX_HMAC_BYTES_B64];
 	unsigned char ts_hmac_buffer[MAX_HMAC_BYTES_B64];


### PR DESCRIPTION
This will allow the library to by compiled with g++ without changing
existing gcc compiling

The g++ compiler compiles all files using C++ standard as opposed to the gcc compiler.  In order to compile in the g++ compiler 2 things needed to be done.
1) Casts needed to be made as automatic casting of void pointers is not allowed.
2) typedefs cannot be reused, each typedef must be unique including pointers to structs.

The new code was was created with #ifdef _cplusplus to insure existing APIs in the C library did not change at all. 
